### PR TITLE
Move state stream subscription to comp did mount.

### DIFF
--- a/lib/stateStreamMixin.js
+++ b/lib/stateStreamMixin.js
@@ -25,8 +25,8 @@ function isObservable(obj) {
 }
 
 /**
- * A Mixin for explicitly boudn the state of a component to an RxJS Observable,
- * subscrition will be disposed on unmount.
+ * A Mixin to explicitly bind the state of a component to an RxJS Observable,
+ * subscription will be disposed on unmount.
  * 
  * var Timer = React.createClass({
  *   mixins: [StateStreamMixin],
@@ -49,25 +49,25 @@ var StateStreamMixin = {
   getInitialState: function () {
     
     var displayName = this.constructor.displayName || this.constructor.name || '';
+    
     invariant(
       typeof this.getStateStream === 'function',
       '%s use the StateStreamMixin it should provide a \'getStateStream\' function',
       displayName
     );
     
-    var stateStream = this.getStateStream(this.props);
+    this.__stateStream = this.getStateStream(this.props);
     
     invariant(
-      isObservable(stateStream),
+      isObservable(this.__stateStream),
       '\'%s.getStateStream\' should return an Rx.Observable, given : %s', 
-      displayName, stateStream
+      displayName, this.__stateStream
     );
     
-    var initializing = true;
     var streamResolved = false;
     var initialState = null;
     
-    this.__stateSubscription = stateStream.subscribe(function (val) {
+    this.__stateStream.first().subscribe(function (val) {
       invariant(
         typeof val === 'object',
         'The observable returned by \'%s.getStateStream\' should publish Objects or null given : %s', 
@@ -75,22 +75,33 @@ var StateStreamMixin = {
       );
       initialState = val;
       streamResolved = true;
-      if (!initializing) {
-        this.setState(val);
-      }
-    }.bind(this));
+    });
     
     if (!streamResolved) {
-      waitForStream(stateStream);
+      waitForStream(this.__stateStream);
     }
     
-    initializing = false;
-
     stateSubscriptions.push(this.__stateSubscription);
     
     return initialState;
   },
   
+  componentDidMount: function() {
+
+    var displayName = this.constructor.displayName || this.constructor.name || '';
+
+    this.__stateSubscription = this.__stateStream.subscribe(function (val) {
+      invariant(
+        typeof val === 'object',
+        'The observable returned by \'%s.getStateStream\' should publish Objects or null given : %s', 
+        displayName, val
+      );
+      this.setState(val);
+    }.bind(this));
+    
+    stateSubscriptions.push(this.__stateSubscription);
+  },
+
   componentWillUnmount: function () {
     if (this.__stateSubscription) {
       this.__stateSubscription.dispose();

--- a/test/stateStreamMixin.js
+++ b/test/stateStreamMixin.js
@@ -129,6 +129,12 @@ test('StateStreamMixin', function (t) {
     
     t.equals(null, StateStreamMixin.getInitialState.call(fakeComponent), 
                  'if the stateStream does not resolve synchronously the getInitialState function should return null');
+
+    StateStreamMixin.componentDidMount.call(fakeComponent);
+
+    t.ok(typeof fakeComponent.__stateSubscription.dispose === 'function', 
+                 'subscribe to stateStream during componentDidMount cycle');
+
     fakeComponent.__stateSubscription.dispose();
     t.end();
   });


### PR DESCRIPTION
This prevents components subscribing to stores during
server side rendering and calling setState afterwards
causing 'document undefined' errors on the server.