### PR TITLE
fix browser alias for webpack compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "browser": {
     "./lib/waitForStream.js": "./lib/waitForStream-browser.js",
-    "./index.js": "browser.js"
+    "./index.js": "./browser.js"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
If you are trying to load this with webpack, the resolve algorithm will try to resolve the browser alias in the following way:

```
...
resolve result /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react/index.js
              aliased from directory description file /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react/package.json with mapping "index.js"
                resolve module browser.js in /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react
                  looking for modules in /Users/djpfahler/localhost/suggest-frontend/node_modules
                    /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js doesn't exist (module as directory)
                    resolve 'file' browser.js in /Users/djpfahler/localhost/suggest-frontend/node_modules
                      resolve file
                        /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js doesn't exist
                        /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js.js doesn't exist
                        /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js.jsx doesn't exist
                        /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js.es6 doesn't exist
                  looking for modules in /Users/djpfahler/localhost/node_modules
                    /Users/djpfahler/localhost/node_modules/browser.js doesn't exist (module as directory)
                    resolve 'file' browser.js in /Users/djpfahler/localhost/node_modules
                      resolve file
                        /Users/djpfahler/localhost/node_modules/browser.js doesn't exist
                        /Users/djpfahler/localhost/node_modules/browser.js.js doesn't exist
                        /Users/djpfahler/localhost/node_modules/browser.js.jsx doesn't exist
                        /Users/djpfahler/localhost/node_modules/browser.js.es6 doesn't exist
        use index.js from package.json
          resolve 'file' or 'directory' index.js in /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react
            resolve file
              resolve result /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react/index.js
                aliased from directory description file /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react/package.json with mapping "index.js"
                  resolve module browser.js in /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react
                    looking for modules in /Users/djpfahler/localhost/suggest-frontend/node_modules
                      /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js doesn't exist (module as directory)
                      resolve 'file' browser.js in /Users/djpfahler/localhost/suggest-frontend/node_modules
                        resolve file
                          /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js doesn't exist
                          /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js.js doesn't exist
                          /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js.jsx doesn't exist
                          /Users/djpfahler/localhost/suggest-frontend/node_modules/browser.js.es6 doesn't exist
                    looking for modules in /Users/djpfahler/localhost/node_modules
                      /Users/djpfahler/localhost/node_modules/browser.js doesn't exist (module as directory)
                      resolve 'file' browser.js in /Users/djpfahler/localhost/node_modules
                        resolve file
                          /Users/djpfahler/localhost/node_modules/browser.js doesn't exist
                          /Users/djpfahler/localhost/node_modules/browser.js.js doesn't exist
                          /Users/djpfahler/localhost/node_modules/browser.js.jsx doesn't exist
                          /Users/djpfahler/localhost/node_modules/browser.js.es6 doesn't exist
              Cannot resolve module 'browser.js' in /Users/djpfahler/localhost/suggest-frontend/node_modules/rx-react
...
```

This is fixed by providing a real local path.