### PR TITLE
Update to newer versions of dependencies and add nicer tests output

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   },
   "peerDependencies": {
     "react": "~0.13.0",
-    "rx": "^2.3.11"
+    "rx": "^3.0.0"
   },
   "devDependencies": {
-    "browserify": "^6.3.3",
+    "browserify": "^11.0.1",
     "jsdom": "^1.3.1",
     "react": "^0.13.0",
-    "reactify": "^0.17.1",
+    "reactify": "^1.1.1",
+    "rx": "^3.0.0",
     "sinon": "^1.12.1",
-    "tape": "^3.0.0",
-    "rx": "^2.3.11"
+    "tape": "^4.0.2"
   },
   "browser": {
     "./lib/waitForStream.js": "./lib/waitForStream-browser.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ReactJS bindings for RxJS",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/testUtils.js test/*.js"
+    "test": "tape test/testUtils.js test/*.js | faucet"
   },
   "keywords": [
     "rx",
@@ -20,7 +20,7 @@
     "url": "https://github.com/fdecampredon/rx-react/issues"
   },
   "author": "François de Campredon <francois.de.campredon@gmail.com>",
-  "licenses" : {
+  "licenses": {
     "type": "Apache",
     "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
   },
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "browserify": "^11.0.1",
+    "faucet": "0.0.1",
     "jsdom": "^1.3.1",
     "react": "^0.13.0",
     "reactify": "^1.1.1",


### PR DESCRIPTION
Nothing major here, just an update to newer versions of dependencies (primarily because of RxJS 3.0.0) and a nicer tests output using faucet.